### PR TITLE
small fix to the schema-creation script and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ It is using OpenAI to build embeddings and Astra/Chroma to store the data.
 - Clone the repository
 - Install the dependencies using `pip install -r requirements.txt`
 - Add your Astra info and OpenAI token in `.env` file
-- If using Astra, create the schema using `schema.cql` file -- _should be automated soon_
+- If using Astra: edit `resources/schema.cql` and replace `YOUR_KEYSPACE_NAME_HERE` with the actual name of your keyspace. Then launch the CQL script to create the schema -- _should be automated soon_
 - Run `client_loader*.py` to import fake clients data in your database from `resources/clients-dataset.csv`
 - Run `main.py` using the command `streamlit run main.py`
-
-
-
-

--- a/resources/schema.cql
+++ b/resources/schema.cql
@@ -1,6 +1,6 @@
-USE bankflix;
+USE YOUR_KEYSPACE_NAME_HERE;
 
-DROP TABLE ClientById;
+DROP TABLE IF EXISTS ClientById;
 
 CREATE TABLE IF NOT EXISTS TotalRevenueByClient (
     client_id INT PRIMARY KEY,
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS ClientById (
 );
 
 CREATE TABLE IF NOT EXISTS TransactionByCustomer (
-....
+    client_id INT,
     embedding_transaction vector<float, 1536>,
     PRIMARY KEY (client_id)
 );
@@ -34,6 +34,3 @@ CREATE TABLE IF NOT EXISTS TransactionByCustomer (
 CREATE CUSTOM INDEX IF NOT EXISTS openai_client ON ClientById (embedding_client) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';
 
 INSERT INTO TotalRevenueByClient (client_id, total_revenue, update_time) VALUES (1, 123123.42, dateOf(now()));
-
-
-


### PR DESCRIPTION
there was a `...` in the `schema.cql` which I guessed/fixed.

Also the script started with a hardcoded `USE <keyspace>`: aligned to the variable-keyspace instructions (.env and all that) and adapted instructions in the readme.